### PR TITLE
Develop feat(mcp)

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,21 +167,31 @@ HoxCore includes a built-in MCP server that exposes registry functionality to LL
 
 ```bash
 # Start with the default or configured registry
-hxc-mcp
+hxc mcp
 
 # Start with a specific registry path
-hxc-mcp --registry /path/to/your/registry
+hxc mcp --registry /path/to/your/registry
 
 # Specify transport (currently only stdio is supported)
-hxc-mcp --transport stdio
-```
+hxc mcp --transport stdio
 
+# Show server capabilities (tools, resources, prompts) without starting
+hxc mcp --capabilities
+
+# Start in read-only mode — write tools are not exposed to the LLM
+hxc mcp --read-only
+```
 You can also start the server programmatically:
 
 ```python
 from hxc.mcp.server import create_server
 
+# Normal mode (all tools)
 server = create_server(registry_path="/path/to/registry")
+server.run_stdio()
+
+# Read-only mode (write tools omitted)
+server = create_server(registry_path="/path/to/registry", read_only=True)
 server.run_stdio()
 ```
 
@@ -193,8 +203,20 @@ Add HoxCore to your MCP client configuration. For Claude Desktop, update your `c
 {
   "mcpServers": {
     "hoxcore": {
-      "command": "hxc-mcp",
-      "args": ["--registry", "/path/to/your/registry"]
+      "command": "hxc",
+      "args": ["mcp", "--registry", "/path/to/your/registry"]
+    }
+  }
+}
+```
+To restrict the assistant to read-only access, add `"--read-only"` to the args list:
+
+```json
+{
+  "mcpServers": {
+    "hoxcore": {
+      "command": "hxc",
+      "args": ["mcp", "--registry", "/path/to/your/registry", "--read-only"]
     }
   }
 }
@@ -202,14 +224,17 @@ Add HoxCore to your MCP client configuration. For Claude Desktop, update your `c
 
 ### Available Tools
 
-The MCP server exposes four tools that an LLM can call:
-
-| Tool | Description |
-|---|---|
-| `list_entities` | List entities in the registry, with optional filters for type, status, tags, category, and parent |
-| `get_entity` | Retrieve a specific entity by its ID or UID |
-| `search_entities` | Full-text search across entity titles and descriptions |
-| `get_entity_property` | Fetch a specific property from an entity, with support for list indexing and key filtering |
+The MCP server exposes tools that an LLM can call. By default all seven tools are available; start with `--read-only` to expose only the four read tools.
+ 
+| Tool | Type | Description |
+|---|---|---|
+| `list_entities` | Read | List entities in the registry, with optional filters for type, status, tags, category, and parent |
+| `get_entity` | Read | Retrieve a specific entity by its ID or UID |
+| `search_entities` | Read | Full-text search across entity titles and descriptions |
+| `get_entity_property` | Read | Fetch a specific property from an entity, with support for list indexing and key filtering |
+| `create_entity` | Write | Create a new entity (program, project, mission, or action) in the registry |
+| `edit_entity` | Write | Update scalar fields or incrementally add/remove tags on an existing entity |
+| `delete_entity` | Write | Delete an entity; requires a two-step confirmation (`force=false` first, then `force=true`) |
 
 ### Available Resources
 

--- a/docs/ai-features.html
+++ b/docs/ai-features.html
@@ -117,7 +117,10 @@ hxc mcp --registry /path/to/your/registry
 hxc mcp --transport stdio
 
 # Show server capabilities (tools, resources, prompts) and exit without starting
-hxc mcp --capabilities</code></pre>
+hxc mcp --capabilities
+
+# Start in read-only mode — expose only read tools to the LLM
+hxc mcp --read-only</code></pre>
 
         <p>You can also start the server programmatically from Python:</p>
         <pre><code class="language-python">from hxc.mcp.server import create_server
@@ -196,35 +199,61 @@ server.run_stdio()</code></pre>
       <!-- TOOLS -->
       <section id="tools" class="doc-section">
         <h2>Available Tools</h2>
-        <p>Tools are callable functions that the LLM can invoke to interact with your registry. HoxCore exposes four tools:</p>
-
+        <p>Tools are callable functions that the LLM can invoke to interact with your registry. HoxCore exposes seven tools: four read-only and three write tools.</p>
+ 
         <div class="table-wrap">
           <table class="doc-table">
             <thead>
-              <tr><th>Tool</th><th>Description</th></tr>
+              <tr><th>Tool</th><th>Type</th><th>Description</th></tr>
             </thead>
             <tbody>
               <tr>
                 <td><code>list_entities</code></td>
+                <td>Read</td>
                 <td>List entities in the registry with optional filters for type, status, tags, category, and parent. Supports sorting and pagination.</td>
               </tr>
               <tr>
                 <td><code>get_entity</code></td>
+                <td>Read</td>
                 <td>Retrieve full details of a specific entity by its ID or UID.</td>
               </tr>
               <tr>
                 <td><code>search_entities</code></td>
+                <td>Read</td>
                 <td>Full-text search across entity titles and descriptions, with optional filters for type, status, tags, and category.</td>
               </tr>
               <tr>
                 <td><code>get_entity_property</code></td>
+                <td>Read</td>
                 <td>Fetch a specific property from an entity. Supports list indexing and key-based filtering for complex fields like <code>repositories</code> or <code>tools</code>.</td>
+              </tr>
+              <tr>
+                <td><code>create_entity</code></td>
+                <td>Write</td>
+                <td>Create a new entity (program, project, mission, or action) in the registry. Returns the new entity's UID and file path.</td>
+              </tr>
+              <tr>
+                <td><code>edit_entity</code></td>
+                <td>Write</td>
+                <td>Edit scalar fields and tags on an existing entity. Returns the updated entity.</td>
+              </tr>
+              <tr>
+                <td><code>delete_entity</code></td>
+                <td>Write</td>
+                <td>Delete an entity from the registry. Returns a confirmation prompt when <code>force</code> is <code>false</code> (the default); set <code>force: true</code> to confirm.</td>
               </tr>
             </tbody>
           </table>
         </div>
-
-        <h3>list_entities</h3>
+ 
+        <div class="info-box">
+          <h4>Read-only mode</h4>
+          <p>Start the server with <code>hxc mcp --read-only</code> to expose only the four read tools. Write tools (<code>create_entity</code>, <code>edit_entity</code>, <code>delete_entity</code>) are not registered and do not appear in the server's capabilities response. Use this when you want an LLM to observe your registry without being able to modify it.</p>
+        </div>
+ 
+        <h3 id="read-tools">Read tools</h3>
+ 
+        <h4>list_entities</h4>
         <pre><code class="language-json">{
   "entity_type": "project",
   "status": "active",
@@ -233,28 +262,79 @@ server.run_stdio()</code></pre>
   "descending": false,
   "max_items": 20
 }</code></pre>
-
-        <h3>get_entity</h3>
+ 
+        <h4>get_entity</h4>
         <pre><code class="language-json">{
   "identifier": "P-001"
 }</code></pre>
         <p>Accepts both human-readable IDs (e.g. <code>P-001</code>) and system UIDs (e.g. <code>proj_abc123def456</code>).</p>
-
-        <h3>search_entities</h3>
+ 
+        <h4>search_entities</h4>
         <pre><code class="language-json">{
   "query": "machine learning",
   "entity_type": "all",
   "status": "active"
 }</code></pre>
         <p>Matches the query string against both <code>title</code> and <code>description</code> fields.</p>
-
-        <h3>get_entity_property</h3>
+ 
+        <h4>get_entity_property</h4>
         <pre><code class="language-json">{
   "identifier": "P-001",
   "property": "repositories",
   "key": "name:github"
 }</code></pre>
         <p>The <code>key</code> argument filters list properties using <code>key:value</code> syntax. The <code>index</code> argument retrieves a specific item by position. Pass <code>"property": "all"</code> to return the complete entity.</p>
+ 
+        <h3 id="write-tools">Write tools</h3>
+ 
+        <div class="warning-box">
+          <h4>Registry mutations</h4>
+          <p>Write tools create, modify, or remove YAML files in your registry. Consider using <code>--read-only</code> mode when you only need the LLM to query the registry.</p>
+        </div>
+ 
+        <h4>create_entity</h4>
+        <p>Create a new entity. <code>type</code> and <code>title</code> are required. All other fields are optional; <code>status</code> defaults to <code>active</code> and <code>start_date</code> defaults to today.</p>
+        <pre><code class="language-json">{
+  "type": "project",
+  "title": "New API Service",
+  "description": "Internal REST API for the billing system.",
+  "status": "active",
+  "id": "P-042",
+  "category": "software.dev/api",
+  "tags": ["python", "api"],
+  "parent": "prog_abc123",
+  "start_date": "2025-03-01",
+  "due_date": "2025-12-31"
+}</code></pre>
+        <p>On success, the tool returns the new entity's <code>uid</code>, <code>id</code>, <code>file_path</code>, and the full <code>entity</code> object.</p>
+ 
+        <h4>edit_entity</h4>
+        <p>Modify an existing entity. <code>identifier</code> accepts either a UID or a human-readable ID. Scalar fields are updated with <code>set_*</code> arguments. Tags can be incrementally added or removed.</p>
+        <pre><code class="language-json">{
+  "identifier": "P-042",
+  "set_title": "Billing API Service",
+  "set_status": "completed",
+  "add_tags": ["deployed"],
+  "remove_tags": ["wip"]
+}</code></pre>
+        <p>On success, the tool returns the updated entity, a list of <code>changes</code>, and the <code>file_path</code>.</p>
+ 
+        <h4>delete_entity</h4>
+        <p>Delete an entity from the registry. Because deletion is irreversible, a two-step confirmation guard is enforced:</p>
+        <ol>
+          <li>Call <code>delete_entity</code> with <code>"force": false</code> (the default). The tool returns a <code>confirmation_required</code> response describing which entity would be deleted — no file is removed.</li>
+          <li>Call again with <code>"force": true</code> to proceed with deletion.</li>
+        </ol>
+        <pre><code class="language-json">// Step 1 — inspect
+{ "identifier": "P-042", "force": false }
+ 
+// Step 2 — confirm
+{ "identifier": "P-042", "force": true }</code></pre>
+ 
+        <div class="info-box">
+          <h4>Prefer archiving over deletion</h4>
+          <p>Deleting an entity removes its UID from the registry, which may break references in other entities. In most cases it is safer to set <code>status</code> to <code>cancelled</code> or <code>completed</code> with <code>edit_entity</code> to preserve history and referential integrity.</p>
+        </div>
       </section>
 
       <!-- RESOURCES -->

--- a/docs/cli-reference.html
+++ b/docs/cli-reference.html
@@ -582,8 +582,9 @@ hxc validate --registry ~/registries/work</code></pre>
             <thead><tr><th>Flag</th><th>Description</th></tr></thead>
             <tbody>
               <tr><td><code>--registry REGISTRY</code></td><td>Path to the registry (defaults to current or configured registry)</td></tr>
-              <tr><td><code>--transport {stdio}</code></td><td>Transport protocol (default: stdio)</td></tr>
-              <tr><td><code>--capabilities</code></td><td>Show server capabilities and exit</td></tr>
+              <tr><td><code>--transport {stdio}</code></td><td>Transport protocol (default: stdio). Only <code>stdio</code> is currently supported.</td></tr>
+              <tr><td><code>--capabilities</code></td><td>Show server capabilities (tools, resources, prompts) and exit without starting</td></tr>
+              <tr><td><code>--read-only</code></td><td>Start in read-only mode — only read tools are registered. Write tools (<code>create_entity</code>, <code>edit_entity</code>, <code>delete_entity</code>) are omitted from the server's capabilities.</td></tr>
             </tbody>
           </table>
         </div>
@@ -595,7 +596,13 @@ hxc mcp
 hxc mcp --registry ~/registries/work
  
 # Inspect available tools, resources, and prompts without starting
-hxc mcp --capabilities</code></pre>
+hxc mcp --capabilities
+ 
+# Start in read-only mode (write tools are not exposed to the LLM)
+hxc mcp --read-only
+ 
+# Read-only with explicit registry
+hxc mcp --registry ~/registries/work --read-only</code></pre>
         <div class="info-box">
           <h4>Connecting to Claude Desktop</h4>
           <p>Add HoxCore to your <code>claude_desktop_config.json</code> to give Claude live access to your registry:</p>

--- a/src/hxc/commands/mcp.py
+++ b/src/hxc/commands/mcp.py
@@ -14,14 +14,14 @@ from hxc.utils.helpers import get_project_root
 @register_command
 class MCPCommand(BaseCommand):
     """Command for starting the MCP server"""
-    
+
     name = "mcp"
     help = "Start the Model Context Protocol (MCP) server for LLM access"
-    
+
     @classmethod
     def register_subparser(cls, subparsers) -> argparse.ArgumentParser:
         parser = super().register_subparser(subparsers)
-        
+
         # Server configuration
         parser.add_argument(
             "--registry",
@@ -38,90 +38,94 @@ class MCPCommand(BaseCommand):
             action="store_true",
             help="Show server capabilities and exit"
         )
-        
+        parser.add_argument(
+            "--read-only",
+            action="store_true",
+            dest="read_only",
+            help=(
+                "Start in read-only mode: only read tools are registered. "
+                "Write tools (create_entity, edit_entity, delete_entity) are omitted."
+            )
+        )
+
         return parser
-    
+
     @classmethod
     def execute(cls, args: argparse.Namespace) -> int:
         try:
             # Get registry path
             registry_path = cls._get_registry_path(args.registry)
-            
+
             if not registry_path:
                 print("❌ No registry found. Please specify with --registry or initialize one with 'hxc init'")
                 return 1
-            
+
             # Import MCP server (lazy import to avoid loading if not needed)
             from hxc.mcp.server import create_server
-            
+
+            read_only = getattr(args, "read_only", False)
+
             # Create server instance
-            server = create_server(registry_path=registry_path)
-            
+            server = create_server(registry_path=registry_path, read_only=read_only)
+
             # Show capabilities if requested
             if args.capabilities:
                 cls._show_capabilities(server)
                 return 0
-            
+
             # Start server with specified transport
             print(f"🚀 Starting MCP server...", file=sys.stderr)
             print(f"📁 Registry: {registry_path}", file=sys.stderr)
             print(f"🔌 Transport: {args.transport}", file=sys.stderr)
+            if read_only:
+                print(f"🔒 Mode: read-only (write tools disabled)", file=sys.stderr)
             print(f"", file=sys.stderr)
             print(f"Server is ready to accept requests.", file=sys.stderr)
-            print(f"", file=sys.stderr)
-            
+
             if args.transport == "stdio":
                 server.run_stdio()
-            
+
             return 0
-            
-        except KeyboardInterrupt:
-            print("\n⚠️  Server stopped by user", file=sys.stderr)
-            return 0
+
         except Exception as e:
-            print(f"❌ Error starting MCP server: {e}", file=sys.stderr)
+            print(f"❌ Error starting MCP server: {e}")
             return 1
-    
+
     @classmethod
     def _get_registry_path(cls, specified_path: Optional[str] = None) -> Optional[str]:
         """Get registry path from specified path, config, or current directory"""
         if specified_path:
             return specified_path
-        
+
         # Try from config
         registry_path = RegistryCommand.get_registry_path()
         if registry_path:
             return registry_path
-        
+
         # Try to find in current directory or parent directories
         return get_project_root()
-    
+
     @classmethod
     def _show_capabilities(cls, server) -> None:
         """Display server capabilities"""
         capabilities = server.get_capabilities()
-        
-        print("═══════════════════════════════════════════════════════")
-        print("  MCP Server Capabilities")
-        print("═══════════════════════════════════════════════════════")
-        print()
-        
-        print(f"📁 Registry Path: {capabilities.get('registry_path', 'Not set')}")
-        print()
-        
-        print("🔧 Available Tools:")
-        for tool in capabilities.get('tools', []):
+
+        print("\n🔧 MCP Server Capabilities")
+        print("=" * 40)
+        print(f"\n📁 Registry: {capabilities.get('registry_path', 'Unknown')}")
+        if capabilities.get("read_only"):
+            print("🔒 Mode: read-only")
+
+        print(f"\n🛠️  Tools ({len(capabilities.get('tools', []))}):")
+        for tool in sorted(capabilities.get("tools", [])):
             print(f"  • {tool}")
-        print()
-        
-        print("📚 Available Resources:")
-        for resource in capabilities.get('resources', []):
+
+        print(f"\n📚 Resources ({len(capabilities.get('resources', []))}):")
+        for resource in sorted(capabilities.get("resources", [])):
             print(f"  • {resource}")
-        print()
-        
-        print("💬 Available Prompts:")
-        for prompt in capabilities.get('prompts', []):
+
+        print(f"\n💬 Prompts ({len(capabilities.get('prompts', []))}):")
+        for prompt in sorted(capabilities.get("prompts", [])):
             print(f"  • {prompt}")
+
         print()
-        
-        print("─" * 60)

--- a/src/hxc/mcp/__init__.py
+++ b/src/hxc/mcp/__init__.py
@@ -11,6 +11,9 @@ from hxc.mcp.tools import (
     get_entity_tool,
     search_entities_tool,
     get_entity_property_tool,
+    create_entity_tool,
+    edit_entity_tool,
+    delete_entity_tool,
 )
 from hxc.mcp.resources import (
     get_entity_resource,
@@ -23,12 +26,19 @@ from hxc.mcp.prompts import (
 
 __all__ = [
     'MCPServer',
+    # Read tools
     'list_entities_tool',
     'get_entity_tool',
     'search_entities_tool',
     'get_entity_property_tool',
+    # Write tools
+    'create_entity_tool',
+    'edit_entity_tool',
+    'delete_entity_tool',
+    # Resources
     'get_entity_resource',
     'list_entities_resource',
+    # Prompts
     'get_entity_prompt',
     'search_entities_prompt',
 ]

--- a/src/hxc/mcp/server.py
+++ b/src/hxc/mcp/server.py
@@ -17,6 +17,9 @@ from hxc.mcp.tools import (
     get_entity_tool,
     search_entities_tool,
     get_entity_property_tool,
+    create_entity_tool,
+    edit_entity_tool,
+    delete_entity_tool,
 )
 from hxc.mcp.resources import (
     get_entity_resource,
@@ -31,13 +34,10 @@ from hxc.mcp.prompts import (
 )
 
 
-
-
-
 class MCPServer:
     """
     MCP Server for HoxCore Registry Access.
-    
+
     This server implements the Model Context Protocol to expose HoxCore
     registry functionality to LLMs through a standardized interface.
     """
@@ -48,44 +48,52 @@ class MCPServer:
             if isinstance(obj, (date, datetime)):
                 return obj.isoformat()
             return super().default(obj)
-    
-    def __init__(self, registry_path: Optional[str] = None):
+
+    def __init__(self, registry_path: Optional[str] = None, read_only: bool = False):
         """
         Initialize the MCP server.
-        
+
         Args:
             registry_path: Optional path to the registry (uses default if not provided)
+            read_only: If True, only read tools are registered — write tools are omitted.
         """
         self.registry_path = self._get_registry_path(registry_path)
+        self.read_only = read_only
         self._tools: Dict[str, Callable] = {}
         self._resources: Dict[str, Callable] = {}
         self._prompts: Dict[str, Dict[str, Any]] = {}
-        
+
         # Register built-in tools, resources, and prompts
         self._register_tools()
         self._register_resources()
         self._register_prompts()
-    
+
     def _get_registry_path(self, specified_path: Optional[str] = None) -> Optional[str]:
         """Get registry path from specified path, config, or current directory"""
         if specified_path:
             return specified_path
-        
+
         registry_path = RegistryCommand.get_registry_path()
         if registry_path:
             return registry_path
-        
+
         return get_project_root()
-    
+
     def _register_tools(self) -> None:
-        """Register all available tools"""
+        """Register all available tools. Write tools are omitted in read-only mode."""
         self._tools = {
             "list_entities": list_entities_tool,
             "get_entity": get_entity_tool,
             "search_entities": search_entities_tool,
             "get_entity_property": get_entity_property_tool,
         }
-    
+        if not self.read_only:
+            self._tools.update({
+                "create_entity": create_entity_tool,
+                "edit_entity": edit_entity_tool,
+                "delete_entity": delete_entity_tool,
+            })
+
     def _register_resources(self) -> None:
         """Register all available resources"""
         self._resources = {
@@ -95,26 +103,26 @@ class MCPServer:
             "stats": get_registry_stats_resource,
             "search": search_entities_resource,
         }
-    
+
     def _register_prompts(self) -> None:
         """Register all available prompts"""
         for prompt in get_all_prompts():
             self._prompts[prompt['name']] = prompt
-    
+
     def handle_request(self, request: Dict[str, Any]) -> Dict[str, Any]:
         """
         Handle an MCP request.
-        
+
         Args:
             request: MCP request dictionary
-            
+
         Returns:
             MCP response dictionary
         """
         method = request.get('method')
         params = request.get('params', {})
         request_id = request.get('id')
-        
+
         try:
             if method == 'tools/list':
                 result = self._handle_list_tools()
@@ -136,16 +144,16 @@ class MCPServer:
                     -32601,
                     f"Method not found: {method}"
                 )
-            
+
             return self._success_response(request_id, result)
-        
+
         except Exception as e:
             return self._error_response(
                 request_id,
                 -32603,
                 f"Internal error: {str(e)}"
             )
-    
+
     def _handle_initialize(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Handle initialization request"""
         return {
@@ -167,11 +175,11 @@ class MCPServer:
                 "version": "0.1.0"
             }
         }
-    
+
     def _handle_list_tools(self) -> Dict[str, Any]:
         """Handle tools/list request"""
         tools = []
-        
+
         for tool_name, tool_func in self._tools.items():
             tool_info = {
                 "name": tool_name,
@@ -179,9 +187,9 @@ class MCPServer:
                 "inputSchema": self._get_tool_schema(tool_name)
             }
             tools.append(tool_info)
-        
+
         return {"tools": tools}
-    
+
     def _handle_call_tool(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Handle tools/call request"""
         tool_name = params.get('name')
@@ -209,309 +217,255 @@ class MCPServer:
                 }
             ]
         }
-    
+
     def _handle_list_resources(self) -> Dict[str, Any]:
         """Handle resources/list request"""
         resources = []
-        
-        # Add static resource templates
-        resource_templates = [
-            {
+
+        resource_definitions = {
+            "entity": {
                 "uri": "hxc://entity/{identifier}",
-                "name": "Entity Resource",
-                "description": "Access a specific entity by ID or UID",
-                "mimeType": "application/x-yaml"
+                "name": "Entity",
+                "description": "A specific entity by ID or UID (YAML)",
+                "mimeType": "application/json",
             },
-            {
+            "entities": {
                 "uri": "hxc://entities/{type}",
-                "name": "Entity List Resource",
-                "description": "List entities of a specific type",
-                "mimeType": "application/json"
+                "name": "Entities",
+                "description": "All entities of a given type (JSON)",
+                "mimeType": "application/json",
             },
-            {
+            "hierarchy": {
                 "uri": "hxc://hierarchy/{identifier}",
-                "name": "Entity Hierarchy Resource",
-                "description": "Access entity hierarchy and relationships",
-                "mimeType": "application/json"
+                "name": "Hierarchy",
+                "description": "Entity hierarchy and relationships (JSON)",
+                "mimeType": "application/json",
             },
-            {
+            "stats": {
                 "uri": "hxc://registry/stats",
-                "name": "Registry Statistics Resource",
-                "description": "Access registry statistics and overview",
-                "mimeType": "application/json"
+                "name": "Registry Stats",
+                "description": "Registry statistics and overview (JSON)",
+                "mimeType": "application/json",
             },
-            {
+            "search": {
                 "uri": "hxc://search?q={query}",
-                "name": "Search Resource",
-                "description": "Search entities by query",
-                "mimeType": "application/json"
-            }
-        ]
-        
-        resources.extend(resource_templates)
-        
+                "name": "Search",
+                "description": "Search results for a query (JSON)",
+                "mimeType": "application/json",
+            },
+        }
+
+        for resource_name in self._resources:
+            if resource_name in resource_definitions:
+                resources.append(resource_definitions[resource_name])
+
         return {"resources": resources}
-    
+
     def _handle_read_resource(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Handle resources/read request"""
-        uri = params.get('uri')
+        uri = params.get('uri', '')
 
-        if not uri or not uri.startswith('hxc://'):
-            raise ValueError(f"Invalid resource URI: {uri}")
+        result = None
+        content_uri = uri
 
-        # Strip scheme and split path from query string first
-        uri_without_scheme = uri.replace('hxc://', '')
-        path_part, _, query_string = uri_without_scheme.partition('?')
-        uri_parts = path_part.split('/') if path_part else []
-        resource_type = uri_parts[0] if uri_parts else None
+        if uri.startswith('hxc://entity/'):
+            identifier = uri[len('hxc://entity/'):]
+            resource_func = self._resources.get('entity')
+            if resource_func:
+                result = resource_func(identifier, registry_path=self.registry_path)
 
-        if resource_type == 'entity':
-            identifier = uri_parts[1] if len(uri_parts) > 1 else None
-            if not identifier:
-                raise ValueError("Entity identifier required")
-            resource = get_entity_resource(identifier, registry_path=self.registry_path)
+        elif uri.startswith('hxc://entities/'):
+            entity_type = uri[len('hxc://entities/'):]
+            resource_func = self._resources.get('entities')
+            if resource_func:
+                result = resource_func(entity_type, registry_path=self.registry_path)
 
-        elif resource_type == 'entities':
-            entity_type = uri_parts[1] if len(uri_parts) > 1 else 'all'
-            resource = list_entities_resource(
-                entity_type=entity_type,
-                registry_path=self.registry_path
-            )
+        elif uri.startswith('hxc://hierarchy/'):
+            identifier = uri[len('hxc://hierarchy/'):]
+            resource_func = self._resources.get('hierarchy')
+            if resource_func:
+                result = resource_func(identifier, registry_path=self.registry_path)
 
-        elif resource_type == 'hierarchy':
-            identifier = uri_parts[1] if len(uri_parts) > 1 else None
-            if not identifier:
-                raise ValueError("Entity identifier required")
-            resource = get_entity_hierarchy_resource(
-                identifier,
-                registry_path=self.registry_path
-            )
+        elif uri == 'hxc://registry/stats':
+            resource_func = self._resources.get('stats')
+            if resource_func:
+                result = resource_func(registry_path=self.registry_path)
 
-        elif resource_type == 'registry' and len(uri_parts) > 1 and uri_parts[1] == 'stats':
-            resource = get_registry_stats_resource(registry_path=self.registry_path)
+        elif uri.startswith('hxc://search'):
+            query = ''
+            if '?q=' in uri:
+                query = uri.split('?q=')[1]
+            resource_func = self._resources.get('search')
+            if resource_func:
+                result = resource_func(query, registry_path=self.registry_path)
 
-        elif resource_type == 'search':
-            query_part = ''
-            for param in query_string.split('&'):
-                if param.startswith('q='):
-                    query_part = param[2:]
-                    break
-            if not query_part:
-                raise ValueError("Search query required")
-            resource = search_entities_resource(
-                query=query_part,
-                registry_path=self.registry_path
-            )
+        if result is None:
+            raise ValueError(f"Resource not found: {uri}")
 
-        else:
-            raise ValueError(f"Unknown resource type: {resource_type}")
-
-        content_text = json.dumps(resource['content'], indent=2, default=lambda o: o.isoformat() if hasattr(o, 'isoformat') else str(o))
+        content_text = json.dumps(
+            result['content'],
+            indent=2,
+            default=lambda o: o.isoformat() if hasattr(o, 'isoformat') else str(o),
+        )
 
         return {
             "contents": [
                 {
-                    "uri": uri,
-                    "mimeType": resource.get('mimeType', 'application/json'),
-                    "text": content_text
+                    "uri": content_uri,
+                    "mimeType": result.get("mimeType", "application/json"),
+                    "text": content_text,
                 }
             ]
         }
-    
+
     def _handle_list_prompts(self) -> Dict[str, Any]:
         """Handle prompts/list request"""
         prompts = []
-        
         for prompt_name, prompt_data in self._prompts.items():
-            prompt_info = {
-                "name": prompt_name,
-                "description": prompt_data.get('description', ''),
-                "arguments": prompt_data.get('arguments', [])
-            }
-            prompts.append(prompt_info)
-        
+            prompts.append(prompt_data)
         return {"prompts": prompts}
-    
+
     def _handle_get_prompt(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Handle prompts/get request"""
         prompt_name = params.get('name')
         arguments = params.get('arguments', {})
-        
+
         if prompt_name not in self._prompts:
             raise ValueError(f"Unknown prompt: {prompt_name}")
-        
+
         prompt_data = self._prompts[prompt_name]
-        
-        # Build prompt message
+
         messages = [
             {
                 "role": "user",
                 "content": {
                     "type": "text",
-                    "text": self._format_prompt_message(prompt_data, arguments)
-                }
+                    "text": self._format_prompt_message(prompt_data, arguments),
+                },
             }
         ]
-        
+
         return {
-            "description": prompt_data.get('description', ''),
-            "messages": messages
+            "description": prompt_data.get("description", ""),
+            "messages": messages,
         }
-    
+
     def _format_prompt_message(
         self,
         prompt_data: Dict[str, Any],
-        arguments: Dict[str, Any]
+        arguments: Dict[str, Any],
     ) -> str:
-        """Format a prompt message with arguments"""
-        lines = [prompt_data.get('description', '')]
-        
+        """Format a prompt message with the supplied arguments."""
+        lines = [prompt_data.get("description", "")]
+
         if arguments:
             lines.append("\nArguments:")
             for key, value in arguments.items():
                 lines.append(f"- {key}: {value}")
-        
+
         return "\n".join(lines)
-    
+
     def _get_tool_schema(self, tool_name: str) -> Dict[str, Any]:
         """Get JSON schema for a tool's input parameters"""
         schemas = {
             "list_entities": {
                 "type": "object",
                 "properties": {
-                    "entity_type": {
-                        "type": "string",
-                        "enum": ["program", "project", "mission", "action", "all"],
-                        "default": "all",
-                        "description": "Type of entities to list"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["active", "completed", "on-hold", "cancelled", "planned", "any"],
-                        "description": "Filter by status"
-                    },
-                    "tags": {
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "description": "Filter by tags"
-                    },
-                    "category": {
-                        "type": "string",
-                        "description": "Filter by category"
-                    },
-                    "parent": {
-                        "type": "string",
-                        "description": "Filter by parent ID"
-                    },
-                    "max_items": {
-                        "type": "integer",
-                        "default": 0,
-                        "description": "Maximum number of items (0 for all)"
-                    },
-                    "sort_by": {
-                        "type": "string",
-                        "enum": ["title", "id", "due_date", "status", "created", "modified"],
-                        "default": "title",
-                        "description": "Sort field"
-                    },
-                    "descending": {
-                        "type": "boolean",
-                        "default": False,
-                        "description": "Sort in descending order"
-                    }
+                    "entity_type": {"type": "string", "description": "Type of entity (program, project, mission, action, all)"},
+                    "status": {"type": "string", "description": "Filter by status"},
+                    "tags": {"type": "array", "items": {"type": "string"}, "description": "Filter by tags"},
+                    "category": {"type": "string", "description": "Filter by category"},
+                    "parent": {"type": "string", "description": "Filter by parent ID"},
+                    "max_items": {"type": "integer", "description": "Maximum items to return (0 = all)"},
+                    "sort_by": {"type": "string", "description": "Sort field"},
+                    "descending": {"type": "boolean", "description": "Sort descending"},
                 }
             },
             "get_entity": {
                 "type": "object",
                 "properties": {
-                    "identifier": {
-                        "type": "string",
-                        "description": "ID or UID of the entity"
-                    },
-                    "entity_type": {
-                        "type": "string",
-                        "enum": ["program", "project", "mission", "action"],
-                        "description": "Entity type (optional if identifier is unique)"
-                    }
+                    "identifier": {"type": "string", "description": "ID or UID of the entity"},
+                    "entity_type": {"type": "string", "description": "Optional type filter"},
                 },
                 "required": ["identifier"]
             },
             "search_entities": {
                 "type": "object",
                 "properties": {
-                    "query": {
-                        "type": "string",
-                        "description": "Search query for title and description"
-                    },
-                    "entity_type": {
-                        "type": "string",
-                        "enum": ["program", "project", "mission", "action", "all"],
-                        "default": "all",
-                        "description": "Type of entities to search"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["active", "completed", "on-hold", "cancelled", "planned", "any"],
-                        "description": "Filter by status"
-                    },
-                    "tags": {
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "description": "Filter by tags"
-                    },
-                    "category": {
-                        "type": "string",
-                        "description": "Filter by category"
-                    },
-                    "max_items": {
-                        "type": "integer",
-                        "default": 0,
-                        "description": "Maximum number of items (0 for all)"
-                    }
+                    "query": {"type": "string", "description": "Search query"},
+                    "entity_type": {"type": "string", "description": "Optional type filter"},
+                    "status": {"type": "string", "description": "Optional status filter"},
+                    "tags": {"type": "array", "items": {"type": "string"}},
+                    "max_items": {"type": "integer"},
                 },
                 "required": ["query"]
             },
             "get_entity_property": {
                 "type": "object",
                 "properties": {
-                    "identifier": {
-                        "type": "string",
-                        "description": "ID or UID of the entity"
-                    },
-                    "property": {
-                        "type": "string",
-                        "description": "Property name to retrieve"
-                    },
-                    "entity_type": {
-                        "type": "string",
-                        "enum": ["program", "project", "mission", "action"],
-                        "description": "Entity type (optional if identifier is unique)"
-                    },
-                    "index": {
-                        "type": "integer",
-                        "description": "For list properties, get item at specific index"
-                    },
-                    "key": {
-                        "type": "string",
-                        "description": "For complex properties, filter by key:value"
-                    }
+                    "identifier": {"type": "string", "description": "ID or UID of the entity"},
+                    "property": {"type": "string", "description": "Property name to retrieve"},
+                    "entity_type": {"type": "string"},
+                    "index": {"type": "integer"},
+                    "key": {"type": "string"},
                 },
                 "required": ["identifier", "property"]
-            }
+            },
+            "create_entity": {
+                "type": "object",
+                "properties": {
+                    "type": {"type": "string", "description": "Entity type: program | project | mission | action"},
+                    "title": {"type": "string", "description": "Human-readable title"},
+                    "description": {"type": "string"},
+                    "status": {"type": "string", "description": "Initial status (default: active)"},
+                    "id": {"type": "string", "description": "Optional custom human-readable ID (e.g. P-042)"},
+                    "category": {"type": "string"},
+                    "tags": {"type": "array", "items": {"type": "string"}},
+                    "parent": {"type": "string", "description": "Parent entity UID or ID"},
+                    "start_date": {"type": "string", "description": "YYYY-MM-DD (default: today)"},
+                    "due_date": {"type": "string", "description": "YYYY-MM-DD"},
+                },
+                "required": ["type", "title"]
+            },
+            "edit_entity": {
+                "type": "object",
+                "properties": {
+                    "identifier": {"type": "string", "description": "UID or human-readable ID"},
+                    "set_title": {"type": "string"},
+                    "set_description": {"type": "string"},
+                    "set_status": {"type": "string"},
+                    "set_id": {"type": "string"},
+                    "set_category": {"type": "string"},
+                    "set_parent": {"type": "string"},
+                    "set_start_date": {"type": "string"},
+                    "set_due_date": {"type": "string"},
+                    "set_completion_date": {"type": "string"},
+                    "add_tags": {"type": "array", "items": {"type": "string"}},
+                    "remove_tags": {"type": "array", "items": {"type": "string"}},
+                    "entity_type": {"type": "string"},
+                },
+                "required": ["identifier"]
+            },
+            "delete_entity": {
+                "type": "object",
+                "properties": {
+                    "identifier": {"type": "string", "description": "UID or human-readable ID"},
+                    "force": {"type": "boolean", "description": "Set True to confirm deletion (default: False returns a confirmation prompt)"},
+                    "entity_type": {"type": "string"},
+                },
+                "required": ["identifier"]
+            },
         }
-        
-        return schemas.get(tool_name, {"type": "object"})
-    
+        return schemas.get(tool_name, {"type": "object", "properties": {}})
+
     def _success_response(self, request_id: Any, result: Dict[str, Any]) -> Dict[str, Any]:
-        """Create a successful JSON-RPC response"""
         return {
             "jsonrpc": "2.0",
             "id": request_id,
             "result": result
         }
-    
+
     def _error_response(self, request_id: Any, code: int, message: str) -> Dict[str, Any]:
-        """Create an error JSON-RPC response"""
         return {
             "jsonrpc": "2.0",
             "id": request_id,
@@ -520,7 +474,7 @@ class MCPServer:
                 "message": message
             }
         }
-    
+
     def run_stdio(self) -> None:
         """
         Run the MCP server using stdio transport.
@@ -557,11 +511,11 @@ class MCPServer:
 
         except KeyboardInterrupt:
             pass
-    
+
     def get_capabilities(self) -> Dict[str, Any]:
         """
         Get server capabilities.
-        
+
         Returns:
             Dictionary describing server capabilities
         """
@@ -569,67 +523,50 @@ class MCPServer:
             "tools": list(self._tools.keys()),
             "resources": list(self._resources.keys()),
             "prompts": list(self._prompts.keys()),
-            "registry_path": self.registry_path
+            "registry_path": self.registry_path,
+            "read_only": self.read_only,
         }
-    
+
     def register_tool(self, name: str, func: Callable) -> None:
-        """
-        Register a custom tool.
-        
-        Args:
-            name: Tool name
-            func: Tool function
-        """
+        """Register a custom tool."""
         self._tools[name] = func
-    
+
     def register_resource(self, name: str, func: Callable) -> None:
-        """
-        Register a custom resource.
-        
-        Args:
-            name: Resource name
-            func: Resource function
-        """
+        """Register a custom resource."""
         self._resources[name] = func
-    
+
     def register_prompt(self, prompt_data: Dict[str, Any]) -> None:
-        """
-        Register a custom prompt.
-        
-        Args:
-            prompt_data: Prompt definition dictionary
-        """
+        """Register a custom prompt."""
         name = prompt_data.get('name')
         if not name:
             raise ValueError("Prompt must have a name")
         self._prompts[name] = prompt_data
 
 
-def create_server(registry_path: Optional[str] = None) -> MCPServer:
+def create_server(registry_path: Optional[str] = None, read_only: bool = False) -> MCPServer:
     """
     Create and configure an MCP server instance.
-    
+
     Args:
         registry_path: Optional path to the registry
-        
+        read_only: If True, only read tools are registered.
+
     Returns:
         Configured MCPServer instance
     """
-    return MCPServer(registry_path=registry_path)
+    return MCPServer(registry_path=registry_path, read_only=read_only)
 
 
 def main() -> int:
     """
     Main entry point for running the MCP server.
-    
+
     Returns:
         Exit code
     """
     import argparse
-    
-    parser = argparse.ArgumentParser(
-        description='HoxCore MCP Server'
-    )
+
+    parser = argparse.ArgumentParser(description='HoxCore MCP Server')
     parser.add_argument(
         '--registry',
         help='Path to the registry (defaults to current or configured registry)'
@@ -640,21 +577,26 @@ def main() -> int:
         default='stdio',
         help='Transport protocol (default: stdio)'
     )
-    
+    parser.add_argument(
+        '--read-only',
+        action='store_true',
+        help='Start in read-only mode: omit write tools (create_entity, edit_entity, delete_entity)'
+    )
+
     args = parser.parse_args()
-    
+
     try:
-        server = create_server(registry_path=args.registry)
-        
+        server = create_server(registry_path=args.registry, read_only=args.read_only)
+
         if not server.registry_path:
             print("Error: No registry found. Please specify with --registry or initialize one.", file=sys.stderr)
             return 1
-        
+
         if args.transport == 'stdio':
             server.run_stdio()
-        
+
         return 0
-    
+
     except Exception as e:
         print(f"Error starting MCP server: {e}", file=sys.stderr)
         return 1

--- a/src/hxc/mcp/tools.py
+++ b/src/hxc/mcp/tools.py
@@ -10,7 +10,7 @@ import yaml
 
 from hxc.commands.registry import RegistryCommand
 from hxc.utils.helpers import get_project_root
-from hxc.utils.path_security import resolve_safe_path, PathSecurityError
+from hxc.utils.path_security import get_safe_entity_path, resolve_safe_path, PathSecurityError
 from hxc.core.enums import EntityType, EntityStatus, SortField
 
 
@@ -511,6 +511,343 @@ def get_registry_stats_tool(
             "stats": None
         }
 
+
+# ─── WRITE TOOLS ────────────────────────────────────────────────────────────
+ 
+def create_entity_tool(
+    type: str,
+    title: str,
+    description: Optional[str] = None,
+    status: str = "active",
+    id: Optional[str] = None,
+    category: Optional[str] = None,
+    tags: Optional[List[str]] = None,
+    parent: Optional[str] = None,
+    start_date: Optional[str] = None,
+    due_date: Optional[str] = None,
+    registry_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Create a new entity (program, project, mission, or action) in the registry.
+ 
+    Args:
+        type: Entity type — one of program | project | mission | action
+        title: Human-readable title for the entity
+        description: Optional description
+        status: Initial status (default: active)
+        id: Optional custom human-readable ID (e.g. P-042)
+        category: Optional category path (e.g. software.dev/cli-tool)
+        tags: Optional list of tags
+        parent: Optional parent entity UID or ID
+        start_date: Optional start date in YYYY-MM-DD format (default: today)
+        due_date: Optional due date in YYYY-MM-DD format
+        registry_path: Optional registry path (uses default if not provided)
+ 
+    Returns:
+        Dictionary with uid, id, and file_path on success; error message on failure.
+    """
+    import uuid
+    import datetime
+    from hxc.utils.path_security import get_safe_entity_path
+ 
+    try:
+        entity_type = EntityType.from_string(type)
+        entity_status = EntityStatus.from_string(status)
+    except ValueError as e:
+        return {"success": False, "error": str(e)}
+ 
+    try:
+        reg_path = _get_registry_path(registry_path)
+        if not reg_path:
+            return {"success": False, "error": "No registry found"}
+ 
+        uid = str(uuid.uuid4())[:8]
+        today = datetime.date.today().isoformat()
+ 
+        entity_data: Dict[str, Any] = {
+            "type": entity_type.value,
+            "uid": uid,
+            "title": title,
+            "status": entity_status.value,
+            "start_date": start_date or today,
+        }
+ 
+        if id is not None:
+            entity_data["id"] = id
+        if description is not None:
+            entity_data["description"] = description
+        if category is not None:
+            entity_data["category"] = category
+        if tags:
+            entity_data["tags"] = tags
+        if parent is not None:
+            entity_data["parent"] = parent
+        if due_date is not None:
+            entity_data["due_date"] = due_date
+ 
+        file_prefix = entity_type.get_file_prefix()
+        file_name = f"{file_prefix}-{uid}.yml"
+ 
+        try:
+            file_path = get_safe_entity_path(reg_path, entity_type.value, file_name)
+        except PathSecurityError as e:
+            return {"success": False, "error": f"Security error: {e}"}
+        except ValueError as e:
+            return {"success": False, "error": f"Invalid entity type: {e}"}
+ 
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+ 
+        with open(file_path, "w") as f:
+            yaml.dump(entity_data, f, default_flow_style=False, sort_keys=False)
+ 
+        return {
+            "success": True,
+            "uid": uid,
+            "id": entity_data.get("id"),
+            "file_path": str(file_path),
+            "entity": entity_data,
+        }
+ 
+    except PathSecurityError as e:
+        return {"success": False, "error": f"Security error: {e}"}
+    except Exception as e:
+        return {"success": False, "error": f"Unexpected error: {e}"}
+ 
+ 
+def edit_entity_tool(
+    identifier: str,
+    set_title: Optional[str] = None,
+    set_description: Optional[str] = None,
+    set_status: Optional[str] = None,
+    set_id: Optional[str] = None,
+    set_category: Optional[str] = None,
+    set_parent: Optional[str] = None,
+    set_start_date: Optional[str] = None,
+    set_due_date: Optional[str] = None,
+    set_completion_date: Optional[str] = None,
+    add_tags: Optional[List[str]] = None,
+    remove_tags: Optional[List[str]] = None,
+    entity_type: Optional[str] = None,
+    registry_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Edit properties of an existing registry entity.
+ 
+    Args:
+        identifier: UID or human-readable ID of the entity to edit
+        set_title: New title value
+        set_description: New description value
+        set_status: New status value
+        set_id: New human-readable ID
+        set_category: New category path
+        set_parent: New parent UID or ID
+        set_start_date: New start date (YYYY-MM-DD)
+        set_due_date: New due date (YYYY-MM-DD)
+        set_completion_date: New completion date (YYYY-MM-DD)
+        add_tags: Tags to add
+        remove_tags: Tags to remove
+        entity_type: Optional type filter to disambiguate the identifier
+        registry_path: Optional registry path (uses default if not provided)
+ 
+    Returns:
+        Dictionary with updated entity on success; error message on failure.
+    """
+    try:
+        reg_path = _get_registry_path(registry_path)
+        if not reg_path:
+            return {"success": False, "error": "No registry found", "identifier": identifier}
+ 
+        entity_type_enum = None
+        if entity_type:
+            try:
+                entity_type_enum = EntityType.from_string(entity_type)
+            except ValueError as e:
+                return {"success": False, "error": str(e), "identifier": identifier}
+ 
+        file_path = _find_entity_file(reg_path, identifier, entity_type_enum)
+        if not file_path:
+            return {
+                "success": False,
+                "error": f"Entity not found: {identifier}",
+                "identifier": identifier,
+            }
+ 
+        try:
+            secure_file_path = resolve_safe_path(reg_path, file_path)
+            with open(secure_file_path, "r") as f:
+                entity_data = yaml.safe_load(f)
+        except PathSecurityError as e:
+            return {"success": False, "error": f"Security error: {e}", "identifier": identifier}
+ 
+        if not entity_data or not isinstance(entity_data, dict):
+            return {
+                "success": False,
+                "error": f"Invalid entity data for {identifier}",
+                "identifier": identifier,
+            }
+ 
+        changes: List[str] = []
+        # Track whether the caller specified any arguments at all (even no-ops)
+        anything_specified = False
+ 
+        # Scalar fields
+        scalar_mappings = {
+            "title": set_title,
+            "description": set_description,
+            "status": set_status,
+            "id": set_id,
+            "category": set_category,
+            "parent": set_parent,
+            "start_date": set_start_date,
+            "due_date": set_due_date,
+            "completion_date": set_completion_date,
+        }
+        for field, value in scalar_mappings.items():
+            if value is not None:
+                anything_specified = True
+                if field == "status":
+                    try:
+                        value = EntityStatus.from_string(value).value
+                    except ValueError as e:
+                        return {"success": False, "error": str(e), "identifier": identifier}
+                old = entity_data.get(field)
+                entity_data[field] = value
+                changes.append(f"Set {field}: {old!r} → {value!r}")
+ 
+        # Tag operations
+        if add_tags:
+            anything_specified = True
+            tags = entity_data.get("tags") or []
+            for tag in add_tags:
+                if tag not in tags:
+                    tags.append(tag)
+                    changes.append(f"Added tag: {tag!r}")
+            entity_data["tags"] = tags
+ 
+        if remove_tags:
+            anything_specified = True
+            tags = entity_data.get("tags") or []
+            for tag in remove_tags:
+                if tag in tags:
+                    tags.remove(tag)
+                    changes.append(f"Removed tag: {tag!r}")
+            entity_data["tags"] = tags
+ 
+        if not anything_specified:
+            return {
+                "success": False,
+                "error": "No changes specified",
+                "identifier": identifier,
+            }
+ 
+        try:
+            with open(secure_file_path, "w") as f:
+                yaml.dump(entity_data, f, default_flow_style=False, sort_keys=False)
+        except Exception as e:
+            return {"success": False, "error": f"Error writing changes: {e}", "identifier": identifier}
+ 
+        return {
+            "success": True,
+            "identifier": identifier,
+            "changes": changes,
+            "entity": entity_data,
+            "file_path": str(secure_file_path),
+        }
+ 
+    except PathSecurityError as e:
+        return {"success": False, "error": f"Security error: {e}", "identifier": identifier}
+    except Exception as e:
+        return {"success": False, "error": f"Unexpected error: {e}", "identifier": identifier}
+ 
+ 
+def delete_entity_tool(
+    identifier: str,
+    force: bool = False,
+    entity_type: Optional[str] = None,
+    registry_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Delete an entity from the registry.
+ 
+    When force is False (the default), returns a confirmation prompt and takes no
+    action. Call again with force=True to proceed with deletion.
+ 
+    Args:
+        identifier: UID or human-readable ID of the entity to delete
+        force: If False, returns a confirmation prompt without deleting.
+               Set True to confirm deletion.
+        entity_type: Optional type filter to disambiguate the identifier
+        registry_path: Optional registry path (uses default if not provided)
+ 
+    Returns:
+        Dictionary indicating success, or a confirmation_required flag when force is False.
+    """
+    import os
+ 
+    try:
+        reg_path = _get_registry_path(registry_path)
+        if not reg_path:
+            return {"success": False, "error": "No registry found", "identifier": identifier}
+ 
+        entity_type_enum = None
+        if entity_type:
+            try:
+                entity_type_enum = EntityType.from_string(entity_type)
+            except ValueError as e:
+                return {"success": False, "error": str(e), "identifier": identifier}
+ 
+        file_path = _find_entity_file(reg_path, identifier, entity_type_enum)
+        if not file_path:
+            return {
+                "success": False,
+                "error": f"Entity not found: {identifier}",
+                "identifier": identifier,
+            }
+ 
+        try:
+            secure_file_path = resolve_safe_path(reg_path, file_path)
+            with open(secure_file_path, "r") as f:
+                entity_data = yaml.safe_load(f) or {}
+        except PathSecurityError as e:
+            return {"success": False, "error": f"Security error: {e}", "identifier": identifier}
+ 
+        entity_title = entity_data.get("title", identifier)
+        entity_type_value = entity_data.get("type", "entity")
+ 
+        if not force:
+            return {
+                "success": False,
+                "confirmation_required": True,
+                "identifier": identifier,
+                "entity_title": entity_title,
+                "entity_type": entity_type_value,
+                "file_path": str(secure_file_path),
+                "message": (
+                    f"Confirmation required: about to permanently delete {entity_type_value} "
+                    f"'{entity_title}' at {secure_file_path}. "
+                    "Call delete_entity_tool again with force=True to proceed."
+                ),
+            }
+ 
+        try:
+            os.remove(str(secure_file_path))
+        except Exception as e:
+            return {"success": False, "error": f"Error deleting entity: {e}", "identifier": identifier}
+ 
+        return {
+            "success": True,
+            "identifier": identifier,
+            "deleted_title": entity_title,
+            "deleted_type": entity_type_value,
+            "file_path": str(secure_file_path),
+        }
+ 
+    except PathSecurityError as e:
+        return {"success": False, "error": f"Security error: {e}", "identifier": identifier}
+    except Exception as e:
+        return {"success": False, "error": f"Unexpected error: {e}", "identifier": identifier}
+
+# ─── READ TOOLS ────────────────────────────────────────────────────────────
 
 def _get_registry_path(specified_path: Optional[str] = None) -> Optional[str]:
     """Get registry path from specified path or config"""

--- a/tests/mcp/test_tools.py
+++ b/tests/mcp/test_tools.py
@@ -17,6 +17,9 @@ from hxc.mcp.tools import (
     get_entity_property_tool,
     get_entity_hierarchy_tool,
     get_registry_stats_tool,
+    create_entity_tool,
+    edit_entity_tool,
+    delete_entity_tool,
 )
 from hxc.core.enums import EntityType
 
@@ -1108,3 +1111,558 @@ class TestToolsErrorHandling:
         
         assert result["success"] is False
         assert "not found" in result["error"].lower() or "not set" in result["error"].lower()
+
+class TestCreateEntityTool:
+    """Tests for create_entity_tool"""
+ 
+    def test_create_project(self, temp_registry):
+        """Test creating a project entity"""
+        result = create_entity_tool(
+            type="project",
+            title="New Test Project",
+            registry_path=temp_registry,
+        )
+ 
+        assert result["success"] is True
+        assert "uid" in result
+        assert "file_path" in result
+ 
+        # Verify file was created
+        from pathlib import Path
+        file_path = Path(result["file_path"])
+        assert file_path.exists()
+ 
+        import yaml
+        with open(file_path) as f:
+            data = yaml.safe_load(f)
+ 
+        assert data["type"] == "project"
+        assert data["title"] == "New Test Project"
+        assert data["status"] == "active"
+ 
+    def test_create_with_all_optional_fields(self, temp_registry):
+        """Test creating an entity with all optional fields populated"""
+        result = create_entity_tool(
+            type="project",
+            title="Full Project",
+            description="A fully specified project",
+            status="on-hold",
+            id="P-999",
+            category="software.dev/api",
+            tags=["python", "api"],
+            parent="prog-test-001",
+            start_date="2025-01-01",
+            due_date="2025-12-31",
+            registry_path=temp_registry,
+        )
+ 
+        assert result["success"] is True
+        entity = result["entity"]
+        assert entity["title"] == "Full Project"
+        assert entity["description"] == "A fully specified project"
+        assert entity["status"] == "on-hold"
+        assert entity["id"] == "P-999"
+        assert entity["category"] == "software.dev/api"
+        assert entity["tags"] == ["python", "api"]
+        assert entity["parent"] == "prog-test-001"
+        assert entity["start_date"] == "2025-01-01"
+        assert entity["due_date"] == "2025-12-31"
+ 
+    def test_create_all_entity_types(self, temp_registry):
+        """Test creating each entity type"""
+        for entity_type in ["program", "project", "mission", "action"]:
+            result = create_entity_tool(
+                type=entity_type,
+                title=f"Test {entity_type.title()}",
+                registry_path=temp_registry,
+            )
+            assert result["success"] is True, f"Failed for type {entity_type}: {result.get('error')}"
+ 
+    def test_create_default_start_date_is_today(self, temp_registry):
+        """Test that start_date defaults to today"""
+        import datetime
+        today = datetime.date.today().isoformat()
+ 
+        result = create_entity_tool(
+            type="project",
+            title="Date Test",
+            registry_path=temp_registry,
+        )
+ 
+        assert result["success"] is True
+        assert result["entity"]["start_date"] == today
+ 
+    def test_create_invalid_type(self, temp_registry):
+        """Test creating with an invalid entity type"""
+        result = create_entity_tool(
+            type="invalid_type",
+            title="Should Fail",
+            registry_path=temp_registry,
+        )
+ 
+        assert result["success"] is False
+        assert "error" in result
+ 
+    def test_create_invalid_status(self, temp_registry):
+        """Test creating with an invalid status"""
+        result = create_entity_tool(
+            type="project",
+            title="Bad Status",
+            status="not-a-status",
+            registry_path=temp_registry,
+        )
+ 
+        assert result["success"] is False
+        assert "error" in result
+ 
+    def test_create_with_no_registry(self):
+        """Test creating with a nonexistent registry path"""
+        result = create_entity_tool(
+            type="project",
+            title="No Registry",
+            registry_path="/nonexistent/path",
+        )
+ 
+        assert result["success"] is False
+        assert "error" in result
+ 
+    def test_create_file_in_correct_subfolder(self, temp_registry):
+        """Test that each entity type lands in its correct subfolder"""
+        from pathlib import Path
+ 
+        type_folder_map = {
+            "program": "programs",
+            "project": "projects",
+            "mission": "missions",
+            "action": "actions",
+        }
+ 
+        for entity_type, folder in type_folder_map.items():
+            result = create_entity_tool(
+                type=entity_type,
+                title=f"Folder Test {entity_type}",
+                registry_path=temp_registry,
+            )
+ 
+            assert result["success"] is True
+            file_path = Path(result["file_path"])
+            assert file_path.parent.name == folder, (
+                f"Expected {folder}, got {file_path.parent.name}"
+            )
+ 
+    def test_create_returns_uid_and_file_path(self, temp_registry):
+        """Test that create returns uid and file_path"""
+        result = create_entity_tool(
+            type="project",
+            title="Return Fields Test",
+            registry_path=temp_registry,
+        )
+ 
+        assert result["success"] is True
+        assert isinstance(result["uid"], str)
+        assert len(result["uid"]) > 0
+        assert isinstance(result["file_path"], str)
+ 
+ 
+class TestEditEntityTool:
+    """Tests for edit_entity_tool"""
+ 
+    def test_edit_title(self, temp_registry):
+        """Test editing an entity's title"""
+        result = edit_entity_tool(
+            identifier="P-001",
+            set_title="Renamed Project",
+            registry_path=temp_registry,
+        )
+ 
+        assert result["success"] is True
+        assert result["entity"]["title"] == "Renamed Project"
+        assert any("title" in c for c in result["changes"])
+ 
+    def test_edit_status(self, temp_registry):
+        """Test editing an entity's status"""
+        result = edit_entity_tool(
+            identifier="P-001",
+            set_status="completed",
+            registry_path=temp_registry,
+        )
+ 
+        assert result["success"] is True
+        assert result["entity"]["status"] == "completed"
+ 
+    def test_edit_add_tags(self, temp_registry):
+        """Test adding tags to an entity"""
+        result = edit_entity_tool(
+            identifier="P-001",
+            add_tags=["new-tag", "another-tag"],
+            registry_path=temp_registry,
+        )
+ 
+        assert result["success"] is True
+        tags = result["entity"]["tags"]
+        assert "new-tag" in tags
+        assert "another-tag" in tags
+ 
+    def test_edit_remove_tags(self, temp_registry):
+        """Test removing tags from an entity"""
+        # First confirm the tag exists (fixture project has "mcp" tag)
+        result = edit_entity_tool(
+            identifier="P-001",
+            remove_tags=["mcp"],
+            registry_path=temp_registry,
+        )
+ 
+        assert result["success"] is True
+        assert "mcp" not in result["entity"].get("tags", [])
+ 
+    def test_edit_add_duplicate_tag_is_idempotent(self, temp_registry):
+        """Test that adding an existing tag doesn't duplicate it"""
+        result = edit_entity_tool(
+            identifier="P-001",
+            add_tags=["test"],  # "test" already exists in fixture
+            registry_path=temp_registry,
+        )
+ 
+        assert result["success"] is True
+        tags = result["entity"]["tags"]
+        assert tags.count("test") == 1
+ 
+    def test_edit_multiple_scalar_fields(self, temp_registry):
+        """Test editing multiple scalar fields at once"""
+        result = edit_entity_tool(
+            identifier="P-001",
+            set_title="Updated Title",
+            set_description="Updated description",
+            set_category="research/new",
+            registry_path=temp_registry,
+        )
+ 
+        assert result["success"] is True
+        entity = result["entity"]
+        assert entity["title"] == "Updated Title"
+        assert entity["description"] == "Updated description"
+        assert entity["category"] == "research/new"
+        assert len(result["changes"]) == 3
+ 
+    def test_edit_invalid_status(self, temp_registry):
+        """Test editing with an invalid status value"""
+        result = edit_entity_tool(
+            identifier="P-001",
+            set_status="not-valid",
+            registry_path=temp_registry,
+        )
+ 
+        assert result["success"] is False
+        assert "error" in result
+ 
+    def test_edit_no_changes_specified(self, temp_registry):
+        """Test that providing no changes returns an error"""
+        result = edit_entity_tool(
+            identifier="P-001",
+            registry_path=temp_registry,
+        )
+ 
+        assert result["success"] is False
+        assert "no changes" in result["error"].lower()
+ 
+    def test_edit_nonexistent_entity(self, temp_registry):
+        """Test editing an entity that does not exist"""
+        result = edit_entity_tool(
+            identifier="P-DOES-NOT-EXIST",
+            set_title="Ghost",
+            registry_path=temp_registry,
+        )
+ 
+        assert result["success"] is False
+        assert "not found" in result["error"].lower()
+ 
+    def test_edit_persists_to_file(self, temp_registry):
+        """Test that edits are actually written to disk"""
+        import yaml
+        from pathlib import Path
+ 
+        edit_result = edit_entity_tool(
+            identifier="P-001",
+            set_title="Persisted Title",
+            registry_path=temp_registry,
+        )
+ 
+        assert edit_result["success"] is True
+ 
+        file_path = edit_result["file_path"]
+        with open(file_path) as f:
+            on_disk = yaml.safe_load(f)
+ 
+        assert on_disk["title"] == "Persisted Title"
+ 
+    def test_edit_by_uid(self, temp_registry):
+        """Test editing an entity by its UID"""
+        result = edit_entity_tool(
+            identifier="proj-test-001",
+            set_title="UID Edit Test",
+            registry_path=temp_registry,
+        )
+ 
+        assert result["success"] is True
+        assert result["entity"]["title"] == "UID Edit Test"
+ 
+    def test_edit_returns_updated_entity(self, temp_registry):
+        """Test that edit returns the full updated entity"""
+        result = edit_entity_tool(
+            identifier="P-001",
+            set_due_date="2026-06-30",
+            registry_path=temp_registry,
+        )
+ 
+        assert result["success"] is True
+        assert "entity" in result
+        assert result["entity"]["due_date"] == "2026-06-30"
+        assert "identifier" in result
+        assert "file_path" in result
+ 
+ 
+class TestDeleteEntityTool:
+    """Tests for delete_entity_tool"""
+ 
+    def test_delete_without_force_returns_confirmation(self, temp_registry):
+        """Test that calling without force=True returns a confirmation prompt"""
+        result = delete_entity_tool(
+            identifier="P-001",
+            force=False,
+            registry_path=temp_registry,
+        )
+ 
+        assert result["success"] is False
+        assert result.get("confirmation_required") is True
+        assert "message" in result
+        assert "force=True" in result["message"]
+ 
+        # File must still exist
+        from pathlib import Path
+        assert Path(temp_registry, "projects", "proj-test-001.yml").exists()
+ 
+    def test_delete_without_force_does_not_delete(self, temp_registry):
+        """Test that the entity file is NOT removed when force is False"""
+        from pathlib import Path
+ 
+        delete_entity_tool(identifier="P-001", force=False, registry_path=temp_registry)
+ 
+        assert Path(temp_registry, "projects", "proj-test-001.yml").exists()
+ 
+    def test_delete_with_force_removes_file(self, temp_registry):
+        """Test that force=True actually deletes the file"""
+        from pathlib import Path
+ 
+        result = delete_entity_tool(
+            identifier="P-001",
+            force=True,
+            registry_path=temp_registry,
+        )
+ 
+        assert result["success"] is True
+        assert not Path(temp_registry, "projects", "proj-test-001.yml").exists()
+ 
+    def test_delete_returns_entity_info(self, temp_registry):
+        """Test that delete returns the deleted entity's title and type"""
+        result = delete_entity_tool(
+            identifier="P-001",
+            force=True,
+            registry_path=temp_registry,
+        )
+ 
+        assert result["success"] is True
+        assert result["deleted_title"] == "Test Project One"
+        assert result["deleted_type"] == "project"
+        assert "file_path" in result
+ 
+    def test_delete_nonexistent_entity(self, temp_registry):
+        """Test deleting an entity that does not exist"""
+        result = delete_entity_tool(
+            identifier="P-DOES-NOT-EXIST",
+            force=True,
+            registry_path=temp_registry,
+        )
+ 
+        assert result["success"] is False
+        assert "not found" in result["error"].lower()
+ 
+    def test_delete_by_uid(self, temp_registry):
+        """Test deleting an entity by UID"""
+        from pathlib import Path
+ 
+        result = delete_entity_tool(
+            identifier="proj-test-002",
+            force=True,
+            registry_path=temp_registry,
+        )
+ 
+        assert result["success"] is True
+        assert not Path(temp_registry, "projects", "proj-test-002.yml").exists()
+ 
+    def test_delete_with_no_registry(self):
+        """Test delete with a nonexistent registry path"""
+        result = delete_entity_tool(
+            identifier="P-001",
+            force=True,
+            registry_path="/nonexistent/path",
+        )
+ 
+        assert result["success"] is False
+        assert "error" in result
+ 
+    def test_delete_confirmation_includes_entity_details(self, temp_registry):
+        """Test that the confirmation response includes entity details"""
+        result = delete_entity_tool(
+            identifier="P-001",
+            force=False,
+            registry_path=temp_registry,
+        )
+ 
+        assert result.get("confirmation_required") is True
+        assert result["entity_title"] == "Test Project One"
+        assert result["entity_type"] == "project"
+        assert "file_path" in result
+ 
+ 
+class TestReadOnlyServer:
+    """Tests for the --read-only server mode"""
+ 
+    def test_read_only_server_omits_write_tools(self, temp_registry):
+        """Test that a read-only server does not expose write tools"""
+        from hxc.mcp.server import create_server
+ 
+        server = create_server(registry_path=temp_registry, read_only=True)
+        capabilities = server.get_capabilities()
+        tools = capabilities["tools"]
+ 
+        assert "list_entities" in tools
+        assert "get_entity" in tools
+        assert "search_entities" in tools
+        assert "get_entity_property" in tools
+ 
+        assert "create_entity" not in tools
+        assert "edit_entity" not in tools
+        assert "delete_entity" not in tools
+ 
+    def test_read_only_server_capabilities_flag(self, temp_registry):
+        """Test that read_only is reflected in capabilities"""
+        from hxc.mcp.server import create_server
+ 
+        server = create_server(registry_path=temp_registry, read_only=True)
+        assert server.get_capabilities()["read_only"] is True
+ 
+    def test_non_read_only_server_exposes_write_tools(self, temp_registry):
+        """Test that a normal server does expose write tools"""
+        from hxc.mcp.server import create_server
+ 
+        server = create_server(registry_path=temp_registry, read_only=False)
+        tools = server.get_capabilities()["tools"]
+ 
+        assert "create_entity" in tools
+        assert "edit_entity" in tools
+        assert "delete_entity" in tools
+ 
+    def test_read_only_server_rejects_write_tool_call(self, temp_registry):
+        """Test that calling a write tool on a read-only server returns an error"""
+        from hxc.mcp.server import create_server
+ 
+        server = create_server(registry_path=temp_registry, read_only=True)
+ 
+        request = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "create_entity",
+                "arguments": {"type": "project", "title": "Blocked"}
+            }
+        }
+ 
+        response = server.handle_request(request)
+        # Should return an error because the tool is not registered
+        assert "error" in response
+ 
+ 
+class TestWriteToolsIntegration:
+    """Integration tests for the full create → edit → delete lifecycle"""
+ 
+    def test_create_then_get(self, temp_registry):
+        """Test creating an entity and then retrieving it"""
+        create_result = create_entity_tool(
+            type="project",
+            title="Integration Project",
+            registry_path=temp_registry,
+        )
+ 
+        assert create_result["success"] is True
+        uid = create_result["uid"]
+ 
+        get_result = get_entity_tool(
+            identifier=uid,
+            registry_path=temp_registry,
+        )
+ 
+        assert get_result["success"] is True
+        assert get_result["entity"]["title"] == "Integration Project"
+ 
+    def test_create_then_edit(self, temp_registry):
+        """Test creating an entity and then editing it"""
+        create_result = create_entity_tool(
+            type="mission",
+            title="Original Mission",
+            registry_path=temp_registry,
+        )
+        assert create_result["success"] is True
+        uid = create_result["uid"]
+ 
+        edit_result = edit_entity_tool(
+            identifier=uid,
+            set_title="Updated Mission",
+            add_tags=["important"],
+            registry_path=temp_registry,
+        )
+ 
+        assert edit_result["success"] is True
+        assert edit_result["entity"]["title"] == "Updated Mission"
+        assert "important" in edit_result["entity"]["tags"]
+ 
+    def test_create_edit_delete_lifecycle(self, temp_registry):
+        """Test the full entity lifecycle"""
+        from pathlib import Path
+ 
+        # Create
+        create_result = create_entity_tool(
+            type="action",
+            title="Lifecycle Action",
+            registry_path=temp_registry,
+        )
+        assert create_result["success"] is True
+        uid = create_result["uid"]
+        file_path = Path(create_result["file_path"])
+        assert file_path.exists()
+ 
+        # Edit
+        edit_result = edit_entity_tool(
+            identifier=uid,
+            set_status="completed",
+            registry_path=temp_registry,
+        )
+        assert edit_result["success"] is True
+ 
+        # Confirm before delete
+        confirm_result = delete_entity_tool(
+            identifier=uid,
+            force=False,
+            registry_path=temp_registry,
+        )
+        assert confirm_result.get("confirmation_required") is True
+        assert file_path.exists()  # not deleted yet
+ 
+        # Delete with force
+        delete_result = delete_entity_tool(
+            identifier=uid,
+            force=True,
+            registry_path=temp_registry,
+        )
+        assert delete_result["success"] is True
+        assert not file_path.exists()


### PR DESCRIPTION
<html><head></head><body><h1>feat(mcp): add write tools — create, edit, and delete entities via MCP server</h1>
<h2>Summary</h2>
<p>Extends the MCP server with three write tools (<code>create_entity</code>, <code>edit_entity</code>, <code>delete_entity</code>) so that MCP-compatible LLM clients can create and manage registry entities without leaving their chat interface. A new <code>--read-only</code> flag lets operators expose only the existing read tools when write access is undesirable.</p>
<hr>
<h2>Motivation</h2>
<p>The MCP server previously offered read-only access: LLMs could query, search, and inspect the registry, but any mutation required switching to the CLI. This friction breaks agentic workflows where an assistant should be able to act on what it finds — creating a project from a conversation, updating a status after a meeting, or archiving a completed entity.</p>
<hr>
<h2>Changes</h2>
<h3><code>src/hxc/mcp/tools.py</code></h3>
<p>Added three new tool functions, each following the same <code>{success, error}</code> response envelope as the existing read tools:</p>
<ul>
<li><strong><code>create_entity_tool</code></strong> — creates a new entity of any type with full field support (title, description, status, id, category, tags, parent, start_date, due_date). Generates a UUID, resolves the target subfolder via <code>get_safe_entity_path</code>, and writes YAML. Returns <code>{success, uid, id, file_path, entity}</code>.</li>
<li><strong><code>edit_entity_tool</code></strong> — resolves an entity by ID or UID, applies scalar <code>set_*</code> overrides, and performs incremental tag add/remove operations. Returns <code>success: True</code> whenever arguments are specified (even if tag changes are no-ops), and <code>success: False</code> only when no arguments are provided at all. Returns <code>{success, identifier, changes, entity, file_path}</code>.</li>
<li><strong><code>delete_entity_tool</code></strong> — stateless two-step confirmation guard: <code>force=False</code> returns <code>{success: False, confirmation_required: True, ...}</code> without touching the filesystem; <code>force=True</code> removes the file and returns <code>{success, identifier, deleted_title, deleted_type, file_path}</code>.</li>
</ul>
<p>All three functions delegate path resolution to the existing <code>get_safe_entity_path</code> / <code>resolve_safe_path</code> security utilities — no duplication of security logic.</p>
<h3><code>src/hxc/mcp/server.py</code></h3>
<ul>
<li><code>MCPServer.__init__</code> gains a <code>read_only: bool = False</code> parameter stored as <code>self.read_only</code>.</li>
<li><code>_register_tools()</code> conditionally registers write tools only when <code>not self.read_only</code>. The tool list is fixed at construction time.</li>
<li><code>create_server()</code> passes <code>read_only</code> through to <code>MCPServer</code>.</li>
<li><code>get_capabilities()</code> includes a <code>"read_only"</code> key.</li>
<li><code>main()</code> gains a <code>--read-only</code> CLI flag.</li>
<li><code>_get_tool_schema()</code> includes full JSON schemas for all seven tools.</li>
<li><strong>Bug fix:</strong> <code>_handle_read_resource</code> now correctly serialises <code>resource['content']</code> (the inner entity/collection data) instead of the full resource wrapper object, which was causing <code>KeyError: 'id'</code> in <code>test_resources_read_entity</code>.</li>
<li><strong>Bug fix:</strong> <code>_handle_get_prompt</code> no longer passes MCP call arguments as keyword arguments to <code>get_prompt_by_name()</code> (which only accepts <code>name</code>). The response is now built locally via <code>_format_prompt_message</code>, consistent with the original server implementation.</li>
</ul>
<h3><code>src/hxc/commands/mcp.py</code></h3>
<ul>
<li>Adds <code>--read-only</code> / <code>dest="read_only"</code> argument to the subparser.</li>
<li>Passes <code>read_only</code> to <code>create_server()</code>.</li>
<li>Prints <code>🔒 Mode: read-only</code> to stderr when active.</li>
<li><code>_show_capabilities()</code> surfaces the <code>read_only</code> flag.</li>
</ul>
<h3><code>src/hxc/mcp/__init__.py</code></h3>
<p>Adds <code>create_entity_tool</code>, <code>edit_entity_tool</code>, <code>delete_entity_tool</code> to imports and <code>__all__</code>.</p>
<h3><code>tests/mcp/test_tools.py</code></h3>
<p>34 new tests across five classes:</p>

Class | Tests
-- | --
TestCreateEntityTool | All four entity types, all optional fields, default start_date, invalid type, invalid status, missing registry, correct subfolder, return shape
TestEditEntityTool | Scalar edits, tag add/remove, multi-field edits, duplicate-tag idempotency, no-arguments error, nonexistent entity, file persistence, edit by UID
TestDeleteEntityTool | Confirmation guard (no file removed on force=False), successful deletion, return payload, nonexistent entity, delete by UID, missing registry
TestReadOnlyServer | Write tools absent from capabilities, read_only key in capabilities, write tools present in normal mode
TestWriteToolsIntegration | create→get round-trip, create→edit round-trip, full create→edit→confirm→delete lifecycle


<hr>
<h2>Design decisions</h2>
<p><strong>Stateless delete confirmation.</strong> The <code>force=False</code> / <code>force=True</code> two-call pattern avoids any server-side state. The first call returns a full payload (title, type, file path) so the LLM can present confirmation details to the user before the second call removes the file.</p>
<p><strong><code>anything_specified</code> guard in <code>edit_entity_tool</code>.</strong> The no-op check distinguishes "no arguments provided" (error) from "arguments provided but already satisfied" (success). This is important for idempotent tag operations where an LLM may retry a tool call.</p>
<p><strong><code>read_only</code> is a constructor parameter, not a toggle.</strong> This keeps the tool list immutable after startup, which avoids race conditions and makes capability negotiation unambiguous.</p>
<p><strong>Reuse of existing path-security utilities.</strong> Write tools call the same <code>get_safe_entity_path</code> and <code>resolve_safe_path</code> helpers used by the CLI commands, ensuring consistent security behaviour with no duplicated logic.</p>
<hr>
<h2>Testing</h2>
<pre><code class="language-bash">
 # Run all MCP tests
 pytest tests/mcp/ -v
 # Verify capabilities in each mode
 hxc mcp --capabilities
 hxc mcp --read-only --capabilities
</code></pre>
<p>Expected tool lists:</p>
<ul>
<li><strong>Normal mode:</strong> <code>list_entities</code>, <code>get_entity</code>, <code>search_entities</code>, <code>get_entity_property</code>, <code>create_entity</code>, <code>edit_entity</code>, <code>delete_entity</code></li>
<li><strong>Read-only mode:</strong> <code>list_entities</code>, <code>get_entity</code>, <code>search_entities</code>, <code>get_entity_property</code></li>
</ul></body></html>