### PR TITLE
Implement auto ID generation from normalized entity name

### DIFF
--- a/src/hxc/commands/create.py
+++ b/src/hxc/commands/create.py
@@ -8,14 +8,56 @@ import datetime
 from pathlib import Path
 import argparse
 from typing import Dict, Any, List, Optional
+import re
+import unicodedata
+import random
+import string
 
 from hxc.commands import register_command
 from hxc.commands.base import BaseCommand
 from hxc.commands.registry import RegistryCommand
 from hxc.utils.helpers import get_project_root
-from hxc.utils.path_security import get_safe_entity_path, PathSecurityError
+from hxc.utils.path_security import get_safe_entity_path, resolve_safe_path, PathSecurityError
 from hxc.core.enums import EntityType, EntityStatus
 
+
+MAX_ID_LENGTH = 255
+_ID_ALLOWED_RE = re.compile(r"[^a-z0-9_]+")
+_ID_SPACES_RE = re.compile(r"\s+")
+_UNDERSCORE_RE = re.compile(r"_+")
+
+
+def _transliterate_to_ascii(text: str) -> str:
+    """
+    Convert non-ASCII characters to their closest ASCII representation (or drop them).
+    """
+    normalized = unicodedata.normalize("NFKD", text)
+    return normalized.encode("ascii", "ignore").decode("ascii")
+
+
+def title_to_id(title: str, entity_type:str) -> str:
+    """
+    Deterministically generate a human-readable, filesystem/URL-safe base ID from a title.
+
+    Rules:
+    - Allowed characters: [a-z0-9_]
+    - Spaces/special characters become underscores
+    - Consecutive underscores collapse; leading/trailing underscores removed
+    - Non-ASCII is transliterated/removal via NFKD -> ascii ignore
+    - Result length is capped to 255 chars
+    """
+    raw_title = title if title is not None else ""
+    canonical = _transliterate_to_ascii(raw_title.strip()).lower()
+
+    # Human-readable slug base: map spaces/special chars to underscores, keep [a-z0-9_]
+    slug = _ID_SPACES_RE.sub("_", canonical)
+    slug = _ID_ALLOWED_RE.sub("_", slug)
+    slug = _UNDERSCORE_RE.sub("_", slug).strip("_")
+
+    if not slug:
+        slug = entity_type
+
+    return slug[:MAX_ID_LENGTH]
 
 @register_command
 class CreateCommand(BaseCommand):
@@ -74,10 +116,35 @@ class CreateCommand(BaseCommand):
         if not registry_path:
             print("❌ No registry found. Please specify with --registry or initialize one with 'hxc init'")
             return 1
-            
-        # Generate entity data based on arguments
+
+        # Load all existing IDs for this entity type once.
+        # This avoids re-opening multiple YAML files during suffix resolution.
+        existing_ids = cls._load_existing_ids(registry_path, entity_type)
+
+        # Generate entity data based on arguments (includes uid and base id).
         entity_data = cls._build_entity_data(args, entity_type, entity_status)
-        
+
+        # Resolve ID uniqueness.
+        # - If --id is provided: preserve it, but fail if it already exists.
+        # - If --id is omitted: try base id; if taken use uid3; if still taken use random letter.
+        if args.custom_id:
+            candidate = entity_data.get("id")
+            if isinstance(candidate, str) and candidate in existing_ids:
+                print(
+                    f"❌ {entity_type.value} with id '{candidate}' already exists in this registry"
+                )
+                return 1
+        else:
+            base_id = entity_data.get("id", "")
+            uid = entity_data.get("uid", "")
+            resolved = cls._resolve_auto_id(existing_ids, base_id, uid)
+            if not resolved:
+                print(
+                    f"❌ Could not generate a unique {entity_type.value} id for title '{entity_data.get('title', '')}'"
+                )
+                return 1
+            entity_data["id"] = resolved
+
         # Determine file name
         uid = entity_data.get('uid', str(uuid.uuid4())[:8])
         file_prefix = entity_type.get_file_prefix()
@@ -145,6 +212,8 @@ class CreateCommand(BaseCommand):
         # Add optional fields if provided
         if args.custom_id:
             entity["id"] = args.custom_id
+        else:
+            entity["id"] = title_to_id(args.title, entity_type.value)
         
         if args.description:
             entity["description"] = args.description
@@ -175,3 +244,66 @@ class CreateCommand(BaseCommand):
         entity["knowledge_bases"] = []
         
         return entity
+
+    @classmethod
+    def _load_existing_ids(cls, registry_path: str, entity_type: EntityType) -> set:
+        """
+        Load all `id` fields for existing entities of this type into a set.
+
+        Returns:
+            Set of existing IDs (strings). Missing/invalid ids are ignored.
+        """
+        ids = set()
+        type_dir = resolve_safe_path(registry_path, entity_type.get_folder_name())
+        if not type_dir.exists():
+            return ids
+
+        file_prefix = entity_type.get_file_prefix()
+        for file_path in type_dir.glob(f"{file_prefix}-*.yml"):
+            try:
+                secure_file_path = resolve_safe_path(registry_path, file_path)
+                with open(secure_file_path, "r") as f:
+                    data = yaml.safe_load(f)
+                if isinstance(data, dict):
+                    existing_id = data.get("id")
+                    if isinstance(existing_id, str):
+                        ids.add(existing_id)
+            except PathSecurityError:
+                continue
+            except Exception:
+                continue
+
+        return ids
+
+    @classmethod
+    def _truncate_base_for_suffix(cls, base_id: str, suffix_len: int) -> str:
+        """
+        Truncate base_id to ensure (base_id + suffix) stays within MAX_ID_LENGTH.
+        """
+        max_base_len = MAX_ID_LENGTH - suffix_len
+        return base_id[:max_base_len]
+
+    @classmethod
+    def _resolve_auto_id(cls, existing_ids: set, base_id: str, uid: str) -> Optional[str]:
+        """
+        Resolve a unique ID using the requested collision strategy:
+        1. base_id (no suffix) if unique
+        2. base_id + '_' + first 3 chars of uid
+        3. if still not unique: increase the chars of uid to append
+        4. if still not unique: return None (caller prints an error)
+        """
+        base_id = base_id or "untitled"
+
+        if base_id not in existing_ids:
+            return base_id
+
+        for i in range(3, len(uid)):
+            partial_uid = uid[:i]
+            suffix = f"_{partial_uid}"
+            truncated_base = cls._truncate_base_for_suffix(base_id, len(suffix))
+            candidate = f"{truncated_base}{suffix}"
+
+            if candidate not in existing_ids:
+                return candidate
+
+        return None

--- a/tests/commands/test_create.py
+++ b/tests/commands/test_create.py
@@ -10,6 +10,7 @@ from unittest.mock import patch, MagicMock
 
 from hxc.cli import main
 from hxc.commands.create import CreateCommand
+from hxc.commands.create import title_to_id
 from hxc.commands.registry import RegistryCommand
 from hxc.utils.path_security import PathSecurityError
 from hxc.core.enums import EntityType, EntityStatus
@@ -183,6 +184,88 @@ def test_create_project_full(mock_get_registry_path, temp_registry):
         assert project_data["tags"] == ["cli", "test", "yaml"]
         assert project_data["parent"] == "P-000"
         assert project_data["template"] == "software.dev/cli-tool.default"
+
+
+@patch("hxc.commands.registry.RegistryCommand.get_registry_path")
+def test_create_custom_id_overrides_auto_generation(
+    mock_get_registry_path, temp_registry
+):
+    """Custom `--id` should override the auto-generated title-based id."""
+    mock_get_registry_path.return_value = str(temp_registry)
+
+    title = "My Project"
+    auto_id = title_to_id(title, "project")
+    custom_id = "P-CUSTOM-123"
+
+    with patch("uuid.uuid4", return_value="12345678-1234-5678-1234-567812345678"):
+        result = main(["create", "project", title, "--id", custom_id])
+        assert result == 0
+
+    project_file = temp_registry / "projects" / "proj-12345678.yml"
+    assert project_file.exists()
+
+    with open(project_file, "r") as f:
+        project_data = yaml.safe_load(f)
+
+    assert project_data["uid"] == "12345678"
+    assert project_data["id"] == custom_id
+    assert project_data["id"] != auto_id
+
+
+@patch("hxc.commands.registry.RegistryCommand.get_registry_path")
+def test_create_custom_id_used_exactly_as_provided(
+    mock_get_registry_path, temp_registry
+):
+    """Custom `--id` should be written to YAML exactly as provided."""
+    mock_get_registry_path.return_value = str(temp_registry)
+
+    title = "Test Action"
+    custom_id = "my.Custom-ID_123"
+
+    with patch("uuid.uuid4", return_value="12345678-1234-5678-1234-567812345678"):
+        result = main(["create", "action", title, "--id", custom_id])
+        assert result == 0
+
+    action_file = temp_registry / "actions" / "act-12345678.yml"
+    assert action_file.exists()
+
+    with open(action_file, "r") as f:
+        action_data = yaml.safe_load(f)
+
+    assert action_data["uid"] == "12345678"
+    assert action_data["id"] == custom_id
+
+
+@patch("hxc.commands.registry.RegistryCommand.get_registry_path")
+def test_create_all_entity_types_include_auto_generated_ids_and_uid(
+    mock_get_registry_path, temp_registry
+):
+    """Each entity type should write `uid` and auto-generated `id` to YAML."""
+    mock_get_registry_path.return_value = str(temp_registry)
+
+    for entity_type in EntityType:
+        folder_name = entity_type.get_folder_name()
+        file_prefix = entity_type.get_file_prefix()
+        title = f"Test {entity_type.value.title()}"
+
+        with patch("uuid.uuid4", return_value="12345678-1234-5678-1234-567812345678"):
+            result = main(["create", entity_type.value, title])
+            assert result == 0
+
+        entity_file = temp_registry / folder_name / f"{file_prefix}-12345678.yml"
+        assert entity_file.exists()
+
+        with open(entity_file, "r") as f:
+            entity_data = yaml.safe_load(f)
+
+        assert entity_data["uid"] == "12345678"
+        assert "id" in entity_data
+        assert entity_data["id"] == title_to_id(title, entity_type.value)
+        assert entity_data["title"] == title
+        assert entity_data["type"] == entity_type.value
+
+        # Clean up to keep the registry empty for the next entity_type iteration.
+        entity_file.unlink()
 
 
 @patch("hxc.commands.registry.RegistryCommand.get_registry_path")
@@ -528,3 +611,46 @@ def test_create_validates_status_early(mock_get_registry_path, temp_registry):
             # No files should be created
             project_files = list((temp_registry / "projects").glob("*.yml"))
             assert len(project_files) == 0
+
+
+def test_create_title_to_id_basic_spaces():
+    assert title_to_id("my project", "project") == "my_project"
+
+
+def test_create_title_to_id_multiple_words():
+    assert title_to_id("my awesome project", "project") == "my_awesome_project"
+
+
+def test_create_title_to_id_very_long_title_exceeds_max_length():
+    long_title = "a" * 300
+    out = title_to_id(long_title, "project")
+    assert len(out) == 255
+    assert out == "a" * 255
+
+
+def test_create_title_to_id_special_characters():
+    assert title_to_id("my-project!", "project") == "my_project"
+
+
+def test_create_title_to_id_non_ascii_characters():
+    assert title_to_id("cäfé pròjěčt", "project") == "cafe_project"
+
+
+def test_create_title_to_id_empty_title():
+    assert title_to_id("", "project") == "project"
+
+
+def test_create_title_to_id_whitespace_only_title():
+    assert title_to_id("   ", "project") == "project"
+
+
+def test_create_title_to_id_leading_trailing_whitespace():
+    assert title_to_id("  my project  ", "project") == "my_project"
+
+
+def test_create_title_to_id_consecutive_spaces_collapse():
+    assert title_to_id("my    project", "project") == "my_project"
+
+
+def test_create_title_to_id_mixed_case_is_lowercased():
+    assert title_to_id("My Project", "project") == "my_project"


### PR DESCRIPTION
Fixes #38
## PR Description: Auto-generate human-friendly IDs for `hxc create`
### Summary
This PR improves the `hxc create` command by automatically generating a predictable, human-readable `id` from the entity `title` when `--id` is not provided. It also adds collision-resolution logic, ensures custom IDs are preserved exactly, and updates/extends unit tests accordingly.
### Key Changes
- **Auto ID generation (when `--id` is omitted)**:
  1. Try the base `title_to_id(...)` with **no suffix**.
  2. If it already exists, append `_<uid_first_3_chars>`.
  3. If it still conflicts, try with increasing chars of uid.
  4. If no unique ID can be found after retries, the command fails **gracefully** (returns a clear error and does not create the entity).
- **Custom ID preservation (`--id`)**:
  - If `--id` is explicitly provided, the value is written to YAML **exactly as provided**.
  - If the custom ID already exists for the same entity type, creation fails gracefully.
- **Performance improvement**:
  - At command start, `create` loads all existing `id` values for the target entity type into a `set`.
  - Collision checks then happen in-memory to avoid repeatedly opening/reading YAML files.
### Tests Added/Updated
- **`title_to_id` conversion tests**:
  - Spaces and multi-word titles
  - Very long titles (max length behavior)
  - Special characters
  - Non-ASCII transliteration (e.g., `café` -> `cafe`)
  - Empty/whitespace-only titles (graceful fallback)
  - Leading/trailing whitespace trimming
  - Consecutive spaces collapsing
  - Mixed-case lowercasing
- **`--id` behavior tests**:
  - Verifies `--id` overrides auto-generation
  - Verifies custom IDs are written exactly as provided
- **Integration coverage across entity types**:
  - Ensures `uid` generation remains unchanged
  - Ensures all entity types (`program`, `project`, `mission`, `action`) write the auto-generated `id` into YAML
### Verification
- `pytest` (with plugin autoload disabled due to missing external dependency in this environment) passes successfully.