### PR TITLE
feat: add cross-platform matrix testing to dev publish workflow

### DIFF
--- a/.github/workflows/publish-develop.yml
+++ b/.github/workflows/publish-develop.yml
@@ -15,8 +15,15 @@ jobs:
   # Job 1: Run tests before publishing anything
   # ──────────────────────────────────────────────
   test:
-    name: Run Test Suite
-    runs-on: ubuntu-latest
+    name: Run Test Suite (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Updates the `test` job in `publish-develop.yml` to run against `ubuntu-latest`, `macos-latest`, and `windows-latest` in parallel.

**Changes:**
- Added `strategy.matrix` with three OS targets
- Set `fail-fast: false` to always capture results from all platforms
- Updated job name to include `${{ matrix.os }}` for clarity in the Actions summary
- `publish-dev` continues to depend on `needs: test`, so all three legs must pass before a dev build is published to TestPyPI