### PR TITLE
Missing test cases

### DIFF
--- a/tests/mcp/test_tools.py
+++ b/tests/mcp/test_tools.py
@@ -1398,6 +1398,38 @@ class TestEditEntityTool:
         assert result["success"] is True
         assert result["entity"]["related"] == ["proj-test-001"]
 
+    def test_edit_add_duplicate_related_is_idempotent(self, temp_registry):
+        edit_entity_tool(identifier="P-001", add_related=["proj-test-001"], registry_path=temp_registry)
+
+        result = edit_entity_tool(
+            identifier="P-001",
+            add_related=["proj-test-001"],
+            registry_path=temp_registry
+        )
+
+        assert result["success"] is True
+        assert result["entity"]["related"].count("proj-test-001") == 1
+
+    def test_edit_remove_nonexistent_child_is_noop(self, temp_registry):
+
+        result = edit_entity_tool(
+            identifier="PRG-001",
+            remove_children=["nonexistent-uid"],
+            registry_path=temp_registry
+        )
+
+        assert result["success"] is True  # anything_specified=True, but no error raised
+
+    def test_edit_remove_nonexistent_related_is_noop(self, temp_registry):
+
+        result = edit_entity_tool(
+            identifier="P-001",
+            remove_related=["nonexistent-uid"],
+            registry_path=temp_registry
+        )
+        
+        assert result["success"] is True
+
     def test_edit_multiple_scalar_fields(self, temp_registry):
         """Test editing multiple scalar fields at once"""
         result = edit_entity_tool(


### PR DESCRIPTION
Adding those three tests completes the checklist:

1. `test_edit_add_duplicate_related_is_idempotent` — covers the missing "add duplicate (idempotent)" case for `related`
2. `test_edit_remove_nonexistent_child_is_noop` — covers the missing "remove non-existent (no-op)" case for `children`
3. `test_edit_remove_nonexistent_related_is_noop` — covers the missing "remove non-existent (no-op)" case for `related`

With those added, every combination of (field × scenario) required by the acceptance criteria of the issue  would be covered, and the last checklist item could be checked off.